### PR TITLE
update recipe to use attribute

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ end
 
 git code_path do
   repository "https://github.com/wal-e/wal-e.git"
-  revision "v0.6.5"
+  revision node[:wal_e][:git_version]
   notifies :run, "bash[install_wal_e]"
 end
 


### PR DESCRIPTION
Currently, the code will enforce only revision 0.6.5, instead of
allowing the user-defined attribute to take precedence over the default
version.
