### PR TITLE
add install_method, version attributes and behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WAL-E Cookbook
 
 Installs and configures [WAL-E](https://github.com/wal-e/wal-e) using
 envdir to store configuration. Sets up a crontab entry to perform base
-backups. 
+backups.
 *You still need to configure Postgres manually/separately to
 archive WAL files.*
 
@@ -15,14 +15,15 @@ Tested on Ubuntu 12.04 extensively.
 Attributes
 ----------
 
-[:wal_e][:base_backup][:disabled] - Install wal-e but don't modify the postgres configuration or install the crontab - useful for restore-only environments.
-[:wal_e][:packages] - The packages needed by wal-e. Override if these are installed in your environment elsewhere. 
-[:wal_e][:pips] - Python dependencies needed by wal-e. Override if these are installed in your environment elsewhere
+- [:wal_e][:base_backup][:disabled] - Install wal-e but don't modify the postgres configuration or install the crontab - useful for restore-only environments.
+- [:wal_e][:packages] - The packages needed by wal-e. Override if these are installed in your environment elsewhere.
+- [:wal_e][:pips] - Python dependencies needed by wal-e. Override if these are installed in your environment elsewhere
 
-[:wal_e][:git_version] - 
-[:wal_e][:base_backup] - Specifies the time period to issue cron backups
+- [:wal_e][:install_method] - valid are 'source' and 'pip'
+- [:wal_e][:version] - Specify the version you want to install
+- [:wal_e][:base_backup] - Specifies the time period to issue cron backups
 
-[:wal_e][:pgdata_dir] - Postgres data directory, override for your postgres version
+- [:wal_e][:pgdata_dir] - Postgres data directory, override for your postgres version
 
 Recipes
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,11 @@ default[:wal_e][:pips] = [
   "boto"
 ]
 
-default[:wal_e][:git_version]         = "v0.6.5"
+default[:wal_e][:install_method]      = 'source'
+default[:wal_e][:version]             = '0.6.5'
+
+# DEPRECATED ATTRIBUTE, for backwards compat. Use `:version` instead
+default[:wal_e][:git_version]         = "v#{wal_e[:version]}"
 
 default[:wal_e][:env_dir]             = '/etc/wal-e'
 default[:wal_e][:aws_access_key]      = ''

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,20 +17,28 @@ unless node[:wal_e][:pips].nil?
   end
 end
 
-code_path = "#{Chef::Config[:file_cache_path]}/wal-e"
+# Install from source or pip pacakge
+case node[:wal_e][:install_method]
+when 'source'
+  code_path = "#{Chef::Config[:file_cache_path]}/wal-e"
 
-bash "install_wal_e" do
-  cwd code_path
-  code <<-EOH
-    /usr/bin/python ./setup.py install
-  EOH
-  action :nothing
-end
+  bash "install_wal_e" do
+    cwd code_path
+    code <<-EOH
+      /usr/bin/python ./setup.py install
+    EOH
+    action :nothing
+  end
 
-git code_path do
-  repository "https://github.com/wal-e/wal-e.git"
-  revision "v0.6.5"
-  notifies :run, "bash[install_wal_e]"
+  git code_path do
+    repository "https://github.com/wal-e/wal-e.git"
+    revision "v0.6.5"
+    notifies :run, "bash[install_wal_e]"
+  end
+when 'pip'
+  python_pip 'wal-e' do
+    version node[:wal_e][:version] if node[:wal_e][:version]
+  end
 end
 
 directory node[:wal_e][:env_dir] do


### PR DESCRIPTION
Switch behaviors between source install from git vs pip package install.
Enable setting :version for both package and source.

Docs updated.
