### PR TITLE
handle older versions of ubuntu

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,20 +1,29 @@
 
-default[:wal_e][:packages] = [
-  "python-setuptools",
-  "python-dev",
-  "lzop",
-  "git",
-  "pv",
-  "postgresql-client",
-  "libevent-dev",
-  "daemontools"
-]
+# List of packages WAL-E needs
+pkg_dependencies = %w(
+  daemontools
+  libevent-dev
+  lzop
+  postgresql-client
+  pv
+  python-dev
+  python-setuptools
+)
 
-default[:wal_e][:pips] = [
-  "gevent",
-  "argparse",
-  "boto"
-]
+# Handle older Ubuntu that had a different name
+if node['platform'] == 'ubuntu' && node['platform_version'].to_f < 10.10
+  pkg_dependencies.push 'git-core'
+else
+  pkg_dependencies.push 'git'
+end
+
+default[:wal_e][:packages] = pkg_dependencies
+
+default[:wal_e][:pips] = %w(
+  argparse
+  boto
+  gevent
+)
 
 default[:wal_e][:install_method]      = 'source'
 default[:wal_e][:version]             = '0.6.5'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,20 +2,14 @@
 # Cookbook Name:: wal-e
 # Recipe:: default
 
-#install packages
+# install packages
 unless node[:wal_e][:packages].nil?
-  pkgs = node[:wal_e][:packages]
-  # In older versions of Ubuntu, the package was called `git-core`
-  if node['platform'] == 'ubuntu' && node['platform_version'].to_f < 10.10
-    pkgs.map! { |pkg| pkg == 'git' ? 'git-core' : pkg }
-  end
-
-  pkgs.each do |pkg|
+  node[:wal_e][:packages].each do |pkg|
     package pkg
   end
 end
 
-#install python modules with pip unless overriden
+# install python modules with pip unless overriden
 unless node[:wal_e][:pips].nil?
   include_recipe "python::pip"
   node[:wal_e][:pips].each do |pp|
@@ -53,9 +47,9 @@ directory node[:wal_e][:env_dir] do
   mode    "0550"
 end
 
-vars = {'AWS_ACCESS_KEY_ID'     => node[:wal_e][:aws_access_key],
-        'AWS_SECRET_ACCESS_KEY' => node[:wal_e][:aws_secret_key],
-        'WALE_S3_PREFIX'        => node[:wal_e][:s3_prefix]}
+vars = { 'AWS_ACCESS_KEY_ID'     => node[:wal_e][:aws_access_key],
+         'AWS_SECRET_ACCESS_KEY' => node[:wal_e][:aws_secret_key],
+         'WALE_S3_PREFIX'        => node[:wal_e][:s3_prefix] }
 
 vars.each do |key, value|
   file "#{node[:wal_e][:env_dir]}/#{key}" do


### PR DESCRIPTION
In Precise and newer, the name has been changed to protect the innocent.
This evaluates the logic in the recipe instead of the attributes for no
other reason than it might be clearer to the reader.
