### PR TITLE
factor out the repository address to an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@ default[:wal_e][:pips] = [
 ]
 
 default[:wal_e][:install_method]      = 'source'
+default[:wal_e][:repository_url]      = 'https://github.com/wal-e/wal-e.git'
 default[:wal_e][:version]             = '0.6.5'
 
 # DEPRECATED ATTRIBUTE, for backwards compat. Use `:version` instead

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,7 +31,7 @@ when 'source'
   end
 
   git code_path do
-    repository "https://github.com/wal-e/wal-e.git"
+    repository node[:wal_e][:repository_url]
     revision node[:wal_e][:version]
     notifies :run, "bash[install_wal_e]"
   end


### PR DESCRIPTION
In the instance where someone might want to work on an experiemental branch of
the wal-e codebase on their own fork, in conjunction with the
`revision` attribute, they can now choose where to source the code from.
