### PR TITLE
add attribute to push more options to base backup

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,8 @@ default[:wal_e][:base_backup][:day]     = '*'
 default[:wal_e][:base_backup][:month]   = '*'
 default[:wal_e][:base_backup][:weekday] = '1'
 
+default[:wal_e][:base_backup][:options] = nil
+
 default[:wal_e][:user]                = 'postgres'
 default[:wal_e][:group]               = 'postgres'
 default[:wal_e][:pgdata_dir]          = '/var/lib/postgresql/9.1/main/'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,7 +62,7 @@ end
 
 cron "wal_e_base_backup" do
   user node[:wal_e][:user]
-  command "/usr/bin/envdir #{node[:wal_e][:env_dir]} /usr/local/bin/wal-e backup-push #{node[:wal_e][:pgdata_dir]}"
+  command "/usr/bin/envdir #{node[:wal_e][:env_dir]} /usr/local/bin/wal-e backup-push #{node[:wal_e][:base_backup][:options]} #{node[:wal_e][:pgdata_dir]}"
   not_if { node[:wal_e][:base_backup][:disabled] }
 
   minute node[:wal_e][:base_backup][:minute]


### PR DESCRIPTION
There are other commandline options for backup-push, such as
--cluster-read-rate-limit and --while-offline, et al.

Allowing an operator to specify any or all as a node attribute will inject
these into the cron job's command, in a forma like so:

```
node.override[:wal_e][:base_backup][:options] = '--cluster-read-rate-limit 5000 --while-offline'
```

or any such string.

The inital value of `nil` will be represented by a blank, so the command will
have two spaces between `backup-push` and <data directory> if not provided.
