### PR TITLE
install development requirements for wal-e deps

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@
 pkg_dependencies = %w(
   daemontools
   libevent-dev
+  libxslt-dev
   lzop
   postgresql-client
   pv
@@ -27,7 +28,7 @@ default[:wal_e][:pips] = %w(
 
 default[:wal_e][:install_method]      = 'source'
 default[:wal_e][:repository_url]      = 'https://github.com/wal-e/wal-e.git'
-default[:wal_e][:version]             = '0.6.5'
+default[:wal_e][:version]             = '0.7.0'
 
 # DEPRECATED ATTRIBUTE, for backwards compat. Use `:version` instead
 default[:wal_e][:git_version]         = "v#{wal_e[:version]}"


### PR DESCRIPTION
In https://github.com/wal-e/wal-e/commit/ebd482a85418601372f31648c4b6473e5eb1db06 (version 0.7.0 and higher) new Python package
dependencies were included.
These deps depend on some further development libraries for successful
compilation.

Namely: libxslt1-dev and libxml2-dev - both are provided by a virtual
package libxslt-dev. This package exists on 10.04, 12.04 and 14.04 as a
helper for the namespace to provide the correct packages.
