### PR TITLE
Set a user for python_pip resources

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,4 +49,5 @@ default[:wal_e][:base_backup][:options] = nil
 
 default[:wal_e][:user]                = 'postgres'
 default[:wal_e][:group]               = 'postgres'
+default[:wal_e][:pip_user]            = 'root'
 default[:wal_e][:pgdata_dir]          = '/var/lib/postgresql/9.1/main/'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,7 +13,9 @@ end
 unless node[:wal_e][:pips].nil?
   include_recipe "python::pip"
   node[:wal_e][:pips].each do |pp|
-    python_pip pp
+    python_pip pp do
+      user node[:wal_e][:user]
+    end
   end
 end
 
@@ -38,6 +40,7 @@ when 'source'
 when 'pip'
   python_pip 'wal-e' do
     version node[:wal_e][:version] if node[:wal_e][:version]
+    user node[:wal_e][:user]
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,7 @@ unless node[:wal_e][:pips].nil?
   include_recipe "python::pip"
   node[:wal_e][:pips].each do |pp|
     python_pip pp do
-      user node[:wal_e][:user]
+      user node[:wal_e][:pip_user]
     end
   end
 end
@@ -40,7 +40,7 @@ when 'source'
 when 'pip'
   python_pip 'wal-e' do
     version node[:wal_e][:version] if node[:wal_e][:version]
-    user node[:wal_e][:user]
+    user node[:wal_e][:pip_user]
   end
 end
 


### PR DESCRIPTION
When deploying using debian 7.6, chef-solo (11.16.4) and sudo (e.g. in test-kitchen), pip picks up the wrong (original) user / user home directory and ultimately fails.
This change sets the default user for python_pip to root, but can be adjusted using the attribute.