### PR TITLE
Adds option to install wal-e inside of a virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ Attributes
 
 - [:wal_e][:pgdata_dir] - Postgres data directory, override for your postgres version
 
+- [:wal_e][:virtualenv][:enabled] - Set to true to install wal-e inside of a python virtual environment. Be sure to update you archive commands appropriately.
+
 Recipes
 -------
 
 - default.rb - Installs wal-e
+- virtualenv.rb - Called by default if the virtualenv enabled attribute is set to true
 
 License and Authors
 -------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,12 @@ default[:wal_e][:base_backup][:weekday] = '1'
 
 default[:wal_e][:base_backup][:options] = nil
 
+
+default[:wal_e][:virtualenv][:enabled] = false
+default[:wal_e][:virtualenv][:path] = '/var/virtualenvs/wal-e'
+default[:wal_e][:virtualenv][:activate] = "#{node[:wal_e][:virtualenv][:path]}/bin/activate"
+default[:wal_e][:virtualenv][:helper] = '/etc/postgresql/virtualenvhelper.sh'
+
 default[:wal_e][:user]                = 'postgres'
 default[:wal_e][:group]               = 'postgres'
 default[:wal_e][:pgdata_dir]          = '/var/lib/postgresql/9.1/main/'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 
 # List of packages WAL-E needs
 pkg_dependencies = %w(
+  build-essentials
   daemontools
   libevent-dev
   libxslt-dev

--- a/files/default/virtualenvhelper.sh
+++ b/files/default/virtualenvhelper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#source/credit: https://gist.github.com/parente/826961
+VENV=$1
+if [ -z $VENV ]; then
+    echo "usage: virtualenvhelper [virtualenv_path_to_activate] CMDS"
+    exit 1
+fi
+. ${VENV}
+shift 1
+#echo "Executing $@ in ${VENV}"
+exec "$@"
+deactivate

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,7 @@ end
 
 # install python modules with pip unless overriden
 unless node[:wal_e][:pips].nil?
-  include_recipe "python::pip"
+  include_recipe 'python::pip'
   node[:wal_e][:pips].each do |pp|
     python_pip pp
   end
@@ -22,7 +22,7 @@ case node[:wal_e][:install_method]
 when 'source'
   code_path = "#{Chef::Config[:file_cache_path]}/wal-e"
 
-  bash "install_wal_e" do
+  bash 'install_wal_e' do
     cwd code_path
     code <<-EOH
       /usr/bin/python ./setup.py install
@@ -44,7 +44,7 @@ end
 directory node[:wal_e][:env_dir] do
   user    node[:wal_e][:user]
   group   node[:wal_e][:group]
-  mode    "0550"
+  mode    '0550'
 end
 
 vars = { 'AWS_ACCESS_KEY_ID'     => node[:wal_e][:aws_access_key],
@@ -60,7 +60,7 @@ vars.each do |key, value|
   end
 end
 
-cron "wal_e_base_backup" do
+cron 'wal_e_base_backup' do
   user node[:wal_e][:user]
   command "/usr/bin/envdir #{node[:wal_e][:env_dir]} /usr/local/bin/wal-e backup-push #{node[:wal_e][:base_backup][:options]} #{node[:wal_e][:pgdata_dir]}"
   not_if { node[:wal_e][:base_backup][:disabled] }

--- a/recipes/virtualenv.rb
+++ b/recipes/virtualenv.rb
@@ -1,0 +1,24 @@
+include_recipe 'python'
+
+cookbook_file node[:wal_e][:virtualenv][:helper] do
+  source 'virtualenvhelper.sh'
+  path   node[:wal_e][:virtualenv][:helper]
+  owner  node[:wal_e][:user]
+  mode 0755
+  action :create
+end
+
+directory node[:wal_e][:virtualenv][:path] do
+  owner node[:wal_e][:user]
+  group node[:wal_e][:group]
+  recursive true
+  action :create
+end
+
+python_virtualenv node[:wal_e][:virtualenv][:path] do
+  options '--no-site-packages'
+  owner node[:wal_e][:user]
+  group node[:wal_e][:group]
+  action :create
+end
+


### PR DESCRIPTION
Adds the option to install wal-e inside of a virtualenv.

Should be benign to existing wal-e installs if the attribute `[:wal_e][:virtualenv][:enabled]` remains false (behavior should be identical). 

If the attribute is set to true, it creates the virtualenv using resources from the python cookbook, and activates that virtualenv when installing pips and when calling wal-e.

Tested only on Ubuntu 12.04. 
