### PR TITLE
Add option to set AWS_REGION environment variable.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default[:wal_e][:git_version]         = "v#{wal_e[:version]}"
 default[:wal_e][:env_dir]             = '/etc/wal-e'
 default[:wal_e][:aws_access_key]      = ''
 default[:wal_e][:aws_secret_key]      = ''
+default[:wal_e][:aws_region]          = ''
 default[:wal_e][:s3_prefix]           = ''
 
 default[:wal_e][:base_backup][:disabled]  = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,6 +55,7 @@ vars = {'WALE_S3_PREFIX'        => node[:wal_e][:s3_prefix] }
 if node[:wal_e][:aws_access_key]
   vars['AWS_ACCESS_KEY_ID'] = node[:wal_e][:aws_access_key]
   vars['AWS_SECRET_ACCESS_KEY'] = node[:wal_e][:aws_secret_key]
+  vars['AWS_REGION'] = node[:wal_e][:aws_region]
 end
 
 vars.each do |key, value|


### PR DESCRIPTION
As of [0.9.0](https://github.com/wal-e/wal-e/blob/master/RELEASES.rst#v090), wal-e requires the AWS_REGION environment variable when using AWS. This adds the option to set this environment variable.
